### PR TITLE
[Bug] Fix issue with Eradicate all Console Logs

### DIFF
--- a/src/fileHelper.ts
+++ b/src/fileHelper.ts
@@ -58,7 +58,7 @@ const getGitRepoPath= async () => {
 
 const getAllFiles = (dirPath: string, arrayOfFiles: string[] = []) => {
   // Skip node_modules directory
-  if (dirPath.includes('/node_modules/')) {
+  if (dirPath.includes('node_modules')) {
     return arrayOfFiles;
   }
 


### PR DESCRIPTION
Eradicate all Console Logs was not skipping files in `node_modues` in Windows